### PR TITLE
fix(d3): change prop type to array with shape

### DIFF
--- a/src/components/chart/D3Chart.js
+++ b/src/components/chart/D3Chart.js
@@ -83,7 +83,12 @@ function D3Chart({ data = DEFAULT_DATA }) {
 }
 
 D3Chart.propTypes = {
-  data: PropTypes.object,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    }).isRequired,
+  ).isRequired,
 };
 
 export default D3Chart;


### PR DESCRIPTION
#### Summary

Resolves: 

- Fixes console error with invalid prop type for d3 on repositories page
![Screen Shot 2020-12-13 at 9 53 23 AM](https://user-images.githubusercontent.com/39889198/102015346-16c69a80-3d29-11eb-8b87-38038ff2c15a.png)

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
