### PR TITLE
feat(recoil): add commit history state for repo page

### DIFF
--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -1,19 +1,35 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useRecoilValue } from 'recoil';
+import { userCommitHistoryState } from '../../recoil/atoms/userCommitHistoryState';
 
-export const RepoPage = (props) => {
-  const repoRef = useRef(null);
-  const { repo } = props.match.params;
+export const RepoPage = ({ match }) => {
+  const userCommitHistory = useRecoilValue(userCommitHistoryState);
+  const { user, repo } = match.params;
 
-  const getData = async () => {};
+  const getData = async () => {
+    // TODO: get Data for that specific user/repo and place in userCommitHistoryState
+  };
 
   useEffect(() => {
+    if (!userCommitHistory[user]) {
+      // TODO: if user doesnt exist we have to create the user key
+    }
+
+    if (!userCommitHistory[user][repo]) {
+      // TODO: if repo data doesn't exist, we need to look it up
+    }
+
     getData();
   }, []);
 
   return (
-    <div ref={repoRef}>
+    <div>
       <h1>{repo}</h1>
+      <h1>{user}</h1>
+      {userCommitHistory[user][repo].map((commitData) => {
+        return <div key={commitData.sha}>{commitData.commit.message}</div>;
+      })}
     </div>
   );
 };
@@ -22,6 +38,7 @@ RepoPage.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       repo: PropTypes.string,
+      user: PropTypes.string,
     }),
   }),
 };

--- a/src/components/pages/UserPage.js
+++ b/src/components/pages/UserPage.js
@@ -17,9 +17,8 @@ export const UserPage = ({ match }) => {
   const [username, setUsername] = useState('');
   let [shouldRedirect, setShouldRedirect] = useState(false);
 
-  console.log('!!! userRepos', userRepos);
-
   const getData = async () => {
+    // TODO: rename tempData
     const tempData = {};
     const { data: repoData } = await API.getReposData({
       username: user,
@@ -37,7 +36,6 @@ export const UserPage = ({ match }) => {
           owner: user,
           repo: repo.name,
         });
-        console.log('!!! commitHisoryData', commitHistoryData);
         tempData[repo.name] = commitHistoryData;
       }),
     );

--- a/src/components/pages/UserPage.js
+++ b/src/components/pages/UserPage.js
@@ -51,7 +51,7 @@ export const UserPage = ({ match }) => {
     Object.assign(newUserRepos, { [user]: repoData });
     setUserRepos(newUserRepos);
 
-    // TODO: reword tempData when removing D3 Chart
+    // TODO: reword tempData variable when removing D3 Chart
     const userCommitHistory = { [user]: tempData };
     setUserCommitHistory(userCommitHistory);
   };

--- a/src/components/pages/UserPage.js
+++ b/src/components/pages/UserPage.js
@@ -5,15 +5,19 @@ import API from '../../utils/api';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
 import { userRepoState } from '../../recoil/atoms/userRepoState';
+import { userCommitHistoryState } from '../../recoil/atoms/userCommitHistoryState';
 
 export const UserPage = ({ match }) => {
   const { user } = match.params;
   const [userRepos, setUserRepos] = useRecoilState(userRepoState);
+  const [, setUserCommitHistory] = useRecoilState(userCommitHistoryState);
   const { [user]: repos = [] } = userRepos;
   const [d3Data, setD3Data] = useState({});
   // TODO: rip out our search into its own component
   const [username, setUsername] = useState('');
   let [shouldRedirect, setShouldRedirect] = useState(false);
+
+  console.log('!!! userRepos', userRepos);
 
   const getData = async () => {
     const tempData = {};
@@ -33,6 +37,7 @@ export const UserPage = ({ match }) => {
           owner: user,
           repo: repo.name,
         });
+        console.log('!!! commitHisoryData', commitHistoryData);
         tempData[repo.name] = commitHistoryData;
       }),
     );
@@ -47,6 +52,10 @@ export const UserPage = ({ match }) => {
     const newUserRepos = Object.assign({}, userRepos);
     Object.assign(newUserRepos, { [user]: repoData });
     setUserRepos(newUserRepos);
+
+    // TODO: reword tempData when removing D3 Chart
+    const userCommitHistory = { [user]: tempData };
+    setUserCommitHistory(userCommitHistory);
   };
 
   useEffect(() => {

--- a/src/recoil/atoms/userCommitHistoryState.js
+++ b/src/recoil/atoms/userCommitHistoryState.js
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 
 /**
- * userRepoState is an object with keys being github user and values
+ * userCommitHistoryState is an object with keys being github user and values
  * being an object with the keys of a user's github repo name and the value
  * of that repo's commit history
  */

--- a/src/recoil/atoms/userCommitHistoryState.js
+++ b/src/recoil/atoms/userCommitHistoryState.js
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+/**
+ * userRepoState is an object with keys being github user and values
+ * being an object with the keys of a user's github repo name and the value
+ * of that repo's commit history
+ */
+export const userCommitHistoryState = atom({
+  key: 'userCommitHistoryState',
+  default: {},
+});

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -2,8 +2,8 @@ import { request } from '@octokit/request';
 const TOKEN = process.env.REACT_APP_GITHUB_TOKEN;
 
 /* 
-github API endpoints:
-https://docs.github.com/en/free-pro-team@latest/rest/overview/endpoints-available-for-github-apps
+  github API endpoints:
+  https://docs.github.com/en/free-pro-team@latest/rest/overview/endpoints-available-for-github-apps
 */
 
 const octoRequest = request.defaults({
@@ -35,6 +35,7 @@ const getRepoCommitHistory = async ({
   );
 
   const { sha: earliestSHA } = commitHistory[commitHistory.length - 1];
+  data.pop(); // fixes bug where last commit is duplicated
   data = [...data, ...commitHistory];
 
   if (commitHistory.length > 1) {


### PR DESCRIPTION
#### Summary

Resolves: https://github.com/f1v/full-git-commit-history-app/projects/1#card-51136875 <!-- Link to issue or card if applicable-->

- Renders commit message
- Adds application level state for a user's repo history

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
