### PR TITLE
feat(repo-page): get data if not populated by user page

### DIFF
--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -34,9 +34,11 @@ export const RepoPage = ({ match }) => {
     <div>
       <h1>{repo}</h1>
       <h1>{user}</h1>
-      {commitHistory[user][repo].map((commitData) => {
-        return <div key={commitData.sha}>{commitData.commit.message}</div>;
-      })}
+      {commitHistory[user] && commitHistory[user][repo]
+        ? commitHistory[user][repo].map((commitData) => {
+            return <div key={commitData.sha}>{commitData.commit.message}</div>;
+          })
+        : null}
     </div>
   );
 };

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -23,6 +23,7 @@ export const RepoPage = ({ match }) => {
   useEffect(() => {
     if (!commitHistory[user]) {
       setUserCommitHistory({ ...commitHistory, [user]: {} });
+      return;
     }
 
     if (!commitHistory[user][repo]) {

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -1,33 +1,40 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { userCommitHistoryState } from '../../recoil/atoms/userCommitHistoryState';
+import API from '../../utils/api';
+import { parseRepoData } from '../../utils/github-data-parser';
 
 export const RepoPage = ({ match }) => {
-  const userCommitHistory = useRecoilValue(userCommitHistoryState);
+  const [commitHistory, setUserCommitHistory] = useRecoilState(
+    userCommitHistoryState,
+  );
   const { user, repo } = match.params;
 
   const getData = async () => {
-    // TODO: get Data for that specific user/repo and place in userCommitHistoryState
+    const rawRepoData = await API.getRepoCommitHistory({
+      owner: user,
+      repo,
+    });
+    const repoCommits = parseRepoData(rawRepoData);
+    setUserCommitHistory({ ...commitHistory, [user]: repoCommits });
   };
 
   useEffect(() => {
-    if (!userCommitHistory[user]) {
-      // TODO: if user doesnt exist we have to create the user key
+    if (!commitHistory[user]) {
+      setUserCommitHistory({ ...commitHistory, [user]: {} });
     }
 
-    if (!userCommitHistory[user][repo]) {
-      // TODO: if repo data doesn't exist, we need to look it up
+    if (!commitHistory[user][repo]) {
+      getData();
     }
-
-    getData();
   }, []);
 
   return (
     <div>
       <h1>{repo}</h1>
       <h1>{user}</h1>
-      {userCommitHistory[user][repo].map((commitData) => {
+      {commitHistory[user][repo].map((commitData) => {
         return <div key={commitData.sha}>{commitData.commit.message}</div>;
       })}
     </div>

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -17,7 +17,7 @@ export const RepoPage = ({ match }) => {
       repo,
     });
     const repoCommits = parseRepoData(rawRepoData);
-    setUserCommitHistory({ ...commitHistory, [user]: repoCommits });
+    setUserCommitHistory({ ...commitHistory, [repo]: repoCommits });
   };
 
   useEffect(() => {

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -6,10 +6,10 @@ import API from '../../utils/api';
 import { parseRepoData } from '../../utils/github-data-parser';
 
 export const RepoPage = ({ match }) => {
+  const { user, repo } = match.params;
   const [commitHistory, setUserCommitHistory] = useRecoilState(
     userCommitHistoryState,
   );
-  const { user, repo } = match.params;
 
   const getData = async () => {
     const rawRepoData = await API.getRepoCommitHistory({
@@ -21,12 +21,7 @@ export const RepoPage = ({ match }) => {
   };
 
   useEffect(() => {
-    if (!commitHistory[user]) {
-      setUserCommitHistory({ ...commitHistory, [user]: {} });
-      return;
-    }
-
-    if (!commitHistory[user][repo]) {
+    if (!commitHistory[user] || !commitHistory[user][repo]) {
       getData();
     }
   }, []);

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -17,7 +17,7 @@ export const RepoPage = ({ match }) => {
       repo,
     });
     const repoCommits = parseRepoData(rawRepoData);
-    setUserCommitHistory({ ...commitHistory, [repo]: repoCommits });
+    setUserCommitHistory({ ...commitHistory, [user]: { [repo]: repoCommits } });
   };
 
   useEffect(() => {


### PR DESCRIPTION
#### Summary

Resolves: https://github.com/f1v/full-git-commit-history-app/projects/1#card-52600763 <!-- Link to issue or card if applicable-->

- fixes issue where a user goes straight to a repo page without going to a user page

Preview:
https://deploy-preview-29--git-commits.netlify.app/user/davidholyko/repo/challenge-problems

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
