### PR TITLE
feat(repo-page): add initial commit list to render commit details

### DIFF
--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Divider, Flex, Heading, Link, Text } from '@chakra-ui/react';
+
+const Commit = ({ sha, commit, commiter, author, url }) => {
+  console.log('!!! url', url);
+  console.log('!!! commit', commit);
+  return (
+    <Box mb="12px" maxW="500px">
+      <Flex align="baseline" justify="space-between">
+        <Link href={url} isExternal>
+          <Text fontSize="24px" mb="10px" isTruncated>
+            {commit.message}
+          </Text>
+        </Link>
+      </Flex>
+
+      <Text fontSize="14px">{sha}</Text>
+
+      {author && <Text fontSize="14px">Authored by {commit.author.name}</Text>}
+      {commiter && (
+        <Text fontSize="14px">Commited by {commit.commiter.name}</Text>
+      )}
+      <Text fontSize="14px">Commited on {commit.author.date}</Text>
+      <Divider mt="12px" />
+    </Box>
+  );
+};
+
+export const CommitList = ({ commits, repo }) => {
+  return commits.length ? (
+    <Box mt="40px" textAlign="left">
+      <Heading fontSize="32px" mb="14px" textAlign="center">
+        {repo}
+      </Heading>
+      {commits.map(({ author, commit, commiter, html_url, sha }) => (
+        <Commit
+          key={sha}
+          sha={sha}
+          commit={commit}
+          url={html_url}
+          commiter={commiter}
+          author={author}
+        />
+      ))}
+    </Box>
+  ) : null;
+};
+
+CommitList.propTypes = {
+  commits: PropTypes.arrayOf(PropTypes.object),
+  repo: PropTypes.string,
+};
+
+Commit.propTypes = {
+  author: PropTypes.object,
+  commit: PropTypes.object,
+  commiter: PropTypes.object,
+  sha: PropTypes.string,
+  url: PropTypes.string,
+};

--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { Box, Divider, Flex, Heading, Link, Text } from '@chakra-ui/react';
 
 const Commit = ({ sha, commit, commiter, author, url }) => {
-  console.log('!!! url', url);
-  console.log('!!! commit', commit);
   return (
     <Box mb="12px" maxW="500px">
       <Flex align="baseline" justify="space-between">
@@ -14,9 +12,7 @@ const Commit = ({ sha, commit, commiter, author, url }) => {
           </Text>
         </Link>
       </Flex>
-
       <Text fontSize="14px">{sha}</Text>
-
       {author && <Text fontSize="14px">Authored by {commit.author.name}</Text>}
       {commiter && (
         <Text fontSize="14px">Commited by {commit.commiter.name}</Text>

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -4,6 +4,7 @@ import { useRecoilState } from 'recoil';
 import { userCommitHistoryState } from '../../recoil/atoms/userCommitHistoryState';
 import API from '../../utils/api';
 import { parseRepoData } from '../../utils/github-data-parser';
+import { CommitList } from '../commit-list/CommitList';
 
 export const RepoPage = ({ match }) => {
   const { user, repo } = match.params;
@@ -30,11 +31,9 @@ export const RepoPage = ({ match }) => {
     <div>
       <h1>{repo}</h1>
       <h1>{user}</h1>
-      {commitHistory[user] && commitHistory[user][repo]
-        ? commitHistory[user][repo].map((commitData) => {
-            return <div key={commitData.sha}>{commitData.commit.message}</div>;
-          })
-        : null}
+      {commitHistory[user] && commitHistory[user][repo] ? (
+        <CommitList commits={commitHistory[user][repo]} repo={repo} />
+      ) : null}
     </div>
   );
 };

--- a/src/utils/github-data-parser.js
+++ b/src/utils/github-data-parser.js
@@ -21,7 +21,9 @@ export const parseUserData = (userData) => {
  *
  */
 export const parseRepoData = (repoData) => {
-  return repoData.map(({ sha, commit: { author, message, avatar_url } }) => {
-    return { sha, commit: { author, message, avatar_url } };
-  });
+  return repoData.map(
+    ({ commit: { author, commiter, message, url }, html_url, sha }) => {
+      return { commit: { author, commiter, message, url }, html_url, sha };
+    },
+  );
 };


### PR DESCRIPTION
#### Summary

Resolves: https://github.com/f1v/full-git-commit-history-app/projects/1#card-52605101 <!-- Link to issue or card if applicable-->

- adds commistList with commit data, saves more keys

#### Preview

https://deploy-preview-33--git-commits.netlify.app/user/f1v/repo/full-git-commit-history-app

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
