### PR TITLE
feat(repo-page): add external links to github, add link to user page

### DIFF
--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Divider, Flex, Heading, Link, Text } from '@chakra-ui/react';
+import { Box, Divider, Flex, Link, Text } from '@chakra-ui/react';
 
 const Commit = ({ sha, commit, commiter, author, url }) => {
   return (
@@ -26,9 +26,6 @@ const Commit = ({ sha, commit, commiter, author, url }) => {
 export const CommitList = ({ commits, repo }) => {
   return commits.length ? (
     <Box mt="40px" textAlign="left">
-      <Heading fontSize="32px" mb="14px" textAlign="center">
-        {repo}
-      </Heading>
       {commits.map(({ author, commit, commiter, html_url, sha }) => (
         <Commit
           key={sha}

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -5,6 +5,8 @@ import { userCommitHistoryState } from '../../recoil/atoms/userCommitHistoryStat
 import API from '../../utils/api';
 import { parseRepoData } from '../../utils/github-data-parser';
 import { CommitList } from '../commit-list/CommitList';
+import { Link as RouterLink } from 'react-router-dom';
+import { Box, Divider, Flex, Heading, Link, Text } from '@chakra-ui/react';
 
 export const RepoPage = ({ match }) => {
   const { user, repo } = match.params;
@@ -27,13 +29,17 @@ export const RepoPage = ({ match }) => {
     }
   }, []);
 
+  const commits = (commitHistory[user] && commitHistory[user][repo]) || [];
+
   return (
     <div>
-      <h1>{repo}</h1>
-      <h1>{user}</h1>
-      {commitHistory[user] && commitHistory[user][repo] ? (
-        <CommitList commits={commitHistory[user][repo]} repo={repo} />
-      ) : null}
+      <Heading fontSize="32px" mb="14px" textAlign="center">
+        {repo} by{' '}
+        <Link as={RouterLink} to={`/user/${user}`}>
+          {user}
+        </Link>
+      </Heading>
+      <CommitList commits={commits} repo={repo} />
     </div>
   );
 };

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -30,8 +30,9 @@ export const RepoPage = ({ match }) => {
   }, []);
 
   const commits = (commitHistory[user] && commitHistory[user][repo]) || [];
-  const repoURL = `https://github.com/${user}/${repo}`;
-  const userURL = `https://github.com/${user}`;
+  const baseURL = 'https://github.com';
+  const userURL = `${baseURL}/${user}`;
+  const repoURL = `${userURL}/${repo}`;
 
   return (
     <div>

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -31,15 +31,21 @@ export const RepoPage = ({ match }) => {
 
   const commits = (commitHistory[user] && commitHistory[user][repo]) || [];
   const repoURL = `https://github.com/${user}/${repo}`;
+  const userURL = `https://github.com/${user}`;
 
   return (
     <div>
+      <Heading as="h5" my="30" size="md">
+        <Link as={RouterLink} to={`/user/${user}`}>
+          go back to {user}'s repositories
+        </Link>
+      </Heading>
       <Heading fontSize="32px" mb="14px" textAlign="center">
         <Link href={repoURL} isExternal>
           {repo}
         </Link>
         <Text style={{ display: 'inline' }}> by </Text>
-        <Link as={RouterLink} to={`/user/${user}`}>
+        <Link href={userURL} isExternal>
           {user}
         </Link>
       </Heading>

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -30,11 +30,15 @@ export const RepoPage = ({ match }) => {
   }, []);
 
   const commits = (commitHistory[user] && commitHistory[user][repo]) || [];
+  const repoURL = `https://github.com/${user}/${repo}`;
 
   return (
     <div>
       <Heading fontSize="32px" mb="14px" textAlign="center">
-        {repo} by{' '}
+        <Link href={repoURL} isExternal>
+          {repo}
+        </Link>
+        <Text style={{ display: 'inline' }}> by </Text>
         <Link as={RouterLink} to={`/user/${user}`}>
           {user}
         </Link>


### PR DESCRIPTION
#### Summary

Resolves: 
https://github.com/f1v/full-git-commit-history-app/projects/1#card-52608996
https://github.com/f1v/full-git-commit-history-app/projects/1#card-52658013 <!-- Link to issue or card if applicable-->

- adds link to go back to user page
- removes duplicate user text

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
