### PR TITLE
chore(github): trim down checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,9 @@
 
 <!-- Replace N/A with link to issue or card if applicable-->
 Resolves: N/A
+Card if applicable: [](url)
 
+<!-- Bullet points describing what this PR does -->
 -
 
 #### Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 #### Summary
 
-Resolves: <!-- Link to issue or card if applicable-->
+<!-- Replace N/A with link to issue or card if applicable-->
+Resolves: N/A
 
 -
 
@@ -8,6 +9,3 @@ Resolves: <!-- Link to issue or card if applicable-->
 
 - [ ] Branch is in format `TYPE/scope/description`
 - [ ] PR title is in semantic format `TYPE(scope): description`
-- [ ] Commits Messages are in semantic format `TYPE(scope): description`
-- [ ] Has Summary
-- [ ] Has Labels


### PR DESCRIPTION
#### Summary

Resolves: <!-- Link to issue or card if applicable-->

- reduces the things we have to check off. Labels were originally there if a PR is up for a while. Because were in a hackathon, we PRs are reviewed instantly 

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
- [x] Commits Messages are in semantic format `TYPE(scope): description`
- [x] Has Summary
- [x] Has Labels
