### PR TITLE
feat(user-page): add functionality to hide forked repos by default

### DIFF
--- a/src/components/repo-list/RepoList.js
+++ b/src/components/repo-list/RepoList.js
@@ -7,6 +7,9 @@ import {
   Link,
   Select,
   Text,
+  Switch,
+  FormControl,
+  FormLabel,
 } from '@chakra-ui/react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -15,8 +18,8 @@ import { Link as RouterLink } from 'react-router-dom';
 
 import { sortReposList } from '../../utils';
 
-const Repo = ({ repo, user }) => {
-  const { description, language, name, pushedAt, numStars } = repo;
+const Repo = ({ repo, user, shouldShowForks }) => {
+  const { description, language, name, pushedAt, numStars, fork } = repo;
   const updatedAtForDisplay = `Updated ${moment(pushedAt).fromNow()}`;
   const starsForDisplay = numStars ? (
     <Flex align="baseline">
@@ -26,6 +29,11 @@ const Repo = ({ repo, user }) => {
       </Text>
     </Flex>
   ) : null;
+
+  if (fork && !shouldShowForks) {
+    // by default, do not render forked repos
+    return null;
+  }
 
   return (
     <Box mb="12px" w="550px">
@@ -49,10 +57,15 @@ const Repo = ({ repo, user }) => {
 
 export const RepoList = ({ repos, user }) => {
   const [sortType, setSortType] = useState('lastUpdated');
+  const [shouldShowForks, setShouldShowForks] = useState(false);
 
   const onSortChange = (event) => {
     const sortValue = event.target.value;
     setSortType(sortValue);
+  };
+
+  const onToggleSwitch = () => {
+    setShouldShowForks(!shouldShowForks);
   };
 
   const SelectDropdown = () => (
@@ -70,16 +83,33 @@ export const RepoList = ({ repos, user }) => {
     </Flex>
   );
 
+  let repoList = sortReposList(repos, sortType);
+
   return repos.length ? (
     <Box m="40px 0" textAlign="left">
       <Heading fontSize="28px" mb="16px" textAlign="center">
         {user}'s Repositories
       </Heading>
-
+      <FormControl display="flex" alignItems="center">
+        <FormLabel htmlFor="fork-switch" mb="0">
+          Show Forked Repositories
+        </FormLabel>
+        <Switch
+          id="fork-switch"
+          size="lg"
+          onChange={onToggleSwitch}
+          value={shouldShowForks}
+        />
+      </FormControl>
       <SelectDropdown />
 
-      {sortReposList(repos, sortType).map((repo) => (
-        <Repo key={repo.id} repo={repo} user={user} />
+      {repoList.map((repo) => (
+        <Repo
+          key={repo.id}
+          repo={repo}
+          user={user}
+          shouldShowForks={shouldShowForks}
+        />
       ))}
     </Box>
   ) : null;
@@ -88,6 +118,7 @@ export const RepoList = ({ repos, user }) => {
 Repo.propTypes = {
   repo: PropTypes.object,
   user: PropTypes.string,
+  shouldShowForks: PropTypes.boolean,
 };
 
 RepoList.propTypes = {

--- a/src/components/repo-list/RepoList.js
+++ b/src/components/repo-list/RepoList.js
@@ -118,7 +118,7 @@ export const RepoList = ({ repos, user }) => {
 Repo.propTypes = {
   repo: PropTypes.object,
   user: PropTypes.string,
-  shouldShowForks: PropTypes.boolean,
+  shouldShowForks: PropTypes.bool,
 };
 
 RepoList.propTypes = {

--- a/src/components/repo-list/RepoList.js
+++ b/src/components/repo-list/RepoList.js
@@ -83,8 +83,6 @@ export const RepoList = ({ repos, user }) => {
     </Flex>
   );
 
-  let repoList = sortReposList(repos, sortType);
-
   return repos.length ? (
     <Box m="40px 0" textAlign="left">
       <Heading fontSize="28px" mb="16px" textAlign="center">
@@ -103,7 +101,7 @@ export const RepoList = ({ repos, user }) => {
       </FormControl>
       <SelectDropdown />
 
-      {repoList.map((repo) => (
+      {sortReposList(repos, sortType).map((repo) => (
         <Repo
           key={repo.id}
           repo={repo}

--- a/src/utils/githubDataUtil.js
+++ b/src/utils/githubDataUtil.js
@@ -21,11 +21,10 @@ export const sortReposList = (repos, sortType) => {
 };
 
 /**
- * takes an object from github data from
- * GET /users/{username}/repos
- * and rips out only relevant keys
- * @param {Array} userRepoData
- *
+ * takes an array of from github data objects like
+ * https://api.github.com/users/f1v/repos
+ * and returns a filtered array with only relevant keys
+ * @param {Array} userData
  */
 export const parseUserData = (userData) => {
   return userData.map(
@@ -36,16 +35,16 @@ export const parseUserData = (userData) => {
       language,
       pushed_at: pushedAt,
       stargazers_count: numStars,
-    }) => ({ id, name, description, language, pushedAt, numStars }),
+      fork,
+    }) => ({ id, name, description, language, pushedAt, numStars, fork }),
   );
 };
 
 /**
- * takes an object from github data from
- * GET /repos/{owner}/{repo}/commits?sha=${sha}
- * and rips out only relevant keys
+ * takes an array of from github data objects like
+ * https://api.github.com/repos/f1v/full-git-commit-history-app/commits?sha=461682a
+ * and returns a filtered array with only relevant keys
  * @param {Array} repoData
- *
  */
 export const parseRepoData = (repoData) => {
   return repoData.map(


### PR DESCRIPTION
#### Summary

<!-- Replace N/A with link to issue or card if applicable-->
Resolves: N/A
Card if applicable: [On User Page, implement functionality to default hide forked repos and functionality to unhide -- (note: I was thinking maybe a checkbox that says "Show forked" to toggle on/off)](https://github.com/f1v/full-git-commit-history-app/projects/1#card-52679007)

<!-- Bullet points describing what this PR does -->
- adds switch component to switch showing forked repos

Example:

https://deploy-preview-48--git-commits.netlify.app/user/veiko

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
