### PR TITLE
refactor(user-page): move switch fork component to user page

### DIFF
--- a/src/components/pages/UserPage.js
+++ b/src/components/pages/UserPage.js
@@ -1,4 +1,11 @@
-import { Flex, Heading, Select } from '@chakra-ui/react';
+import {
+  Flex,
+  FormControl,
+  FormLabel,
+  Heading,
+  Select,
+  Switch,
+} from '@chakra-ui/react';
 import React, { useEffect, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useRecoilState } from 'recoil';
@@ -14,6 +21,7 @@ export const UserPage = ({ match }) => {
   const { setIsLoading } = useContext(AppContext);
   const [userRepos, setUserRepos] = useRecoilState(userRepoState);
   const { [user]: currentUserRepos = [] } = userRepos;
+  const [shouldShowForks, setShouldShowForks] = useState(false);
 
   const getData = async () => {
     setIsLoading(true);
@@ -54,6 +62,29 @@ export const UserPage = ({ match }) => {
     </Flex>
   );
 
+  const onToggleSwitch = () => {
+    setShouldShowForks(!shouldShowForks);
+  };
+
+  const ShowForksSwitch = () => (
+    <FormControl
+      display="flex"
+      alignItems="baseline"
+      justifyContent="flex-end"
+      w="550px"
+    >
+      <FormLabel color="#808080" htmlFor="fork-switch" mb="0">
+        Show Forks
+      </FormLabel>
+      <Switch
+        isChecked={shouldShowForks}
+        id="fork-switch"
+        size="sm"
+        onChange={onToggleSwitch}
+      />
+    </FormControl>
+  );
+
   return (
     <>
       <Flex align="center" justify="space-between" mt="25px" w="550px">
@@ -61,7 +92,14 @@ export const UserPage = ({ match }) => {
         <SelectDropdown />
       </Flex>
 
-      <RepoList repos={currentUserRepos} sortType={sortType} user={user} />
+      <ShowForksSwitch shouldShowForks={shouldShowForks} />
+
+      <RepoList
+        repos={currentUserRepos}
+        shouldShowForks={shouldShowForks}
+        sortType={sortType}
+        user={user}
+      />
     </>
   );
 };

--- a/src/components/repo-list/RepoList.js
+++ b/src/components/repo-list/RepoList.js
@@ -1,17 +1,8 @@
 import { StarIcon } from '@chakra-ui/icons';
-import {
-  Box,
-  Divider,
-  Flex,
-  Link,
-  Text,
-  Switch,
-  FormControl,
-  FormLabel,
-} from '@chakra-ui/react';
+import { Box, Divider, Flex, Link, Text } from '@chakra-ui/react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { sortReposList } from '../../utils';
@@ -55,26 +46,9 @@ const Repo = ({ repo, user, shouldShowForks }) => {
   );
 };
 
-export const RepoList = ({ repos, user, sortType }) => {
-  const [shouldShowForks, setShouldShowForks] = useState(false);
-
-  const onToggleSwitch = () => {
-    setShouldShowForks(!shouldShowForks);
-  };
-
+export const RepoList = ({ repos, user, shouldShowForks, sortType }) => {
   return repos.length ? (
     <Box m="40px 0" textAlign="left">
-      <FormControl display="flex" alignItems="center">
-        <FormLabel htmlFor="fork-switch" mb="0">
-          Show Forks
-        </FormLabel>
-        <Switch
-          id="fork-switch"
-          size="lg"
-          onChange={onToggleSwitch}
-          value={shouldShowForks}
-        />
-      </FormControl>
       <Divider borderColor="#808080" mb="24px" />
       {sortReposList(repos, sortType).map((repo) => (
         <Repo
@@ -97,5 +71,6 @@ Repo.propTypes = {
 RepoList.propTypes = {
   repos: PropTypes.array,
   user: PropTypes.string,
+  shouldShowForks: PropTypes.bool,
   sortType: PropTypes.string,
 };


### PR DESCRIPTION
#### Summary



<!-- Bullet points describing what this PR does -->
- Move fork switch for easier styling

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
