### PR TITLE
fix(app): add gray color to secondary text on user and repo pages

### DIFF
--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -10,16 +10,26 @@ const Commit = ({ githubCommitObject }) => {
   return (
     <Box mb="12px" w="550px">
       <Flex align="baseline" justify="space-between">
-        <Link href={url} isExternal>
-          <Text fontSize="24px" maxW="550px" mb="10px" isTruncated>
+        <Link href={url} textDecoration="underline" isExternal>
+          <Text fontSize="20px" maxW="550px" mb="10px" isTruncated>
             {message}
           </Text>
         </Link>
       </Flex>
-      <Text fontSize="14px">{sha}</Text>
-      {author && <Text fontSize="14px">Authored by {author.name}</Text>}
-      {commiter && <Text fontSize="14px">Commited by {commiter.name}</Text>}
-      <Text fontSize="14px">
+      <Text color="#808080" fontSize="14px">
+        {sha}
+      </Text>
+      {author && (
+        <Text color="#808080" fontSize="14px">
+          Authored by {author.name}
+        </Text>
+      )}
+      {commiter && (
+        <Text color="#808080" fontSize="14px">
+          Commited by {commiter.name}
+        </Text>
+      )}
+      <Text color="#808080" fontSize="14px">
         Commited on {moment(author.date).format('MMM Do YYYY, h:mm:ss a')}
       </Text>
       <Divider mt="12px" />
@@ -34,8 +44,14 @@ export const CommitList = ({ commits, branches }) => {
   };
 
   const SelectDropdown = () => (
-    <Flex justifyContent="flex-end" mb="12px">
-      <Select fontSize="15px" onChange={onSelect} w="160px">
+    <Flex justifyContent="flex-end" mb="25px">
+      <Select
+        borderColor="#808080"
+        color="#808080"
+        fontSize="15px"
+        onChange={onSelect}
+        w="160px"
+      >
         {branches.map((branchName, index) => {
           return (
             <option key={index} value={branchName}>

--- a/src/components/pages/RepoPage.js
+++ b/src/components/pages/RepoPage.js
@@ -52,7 +52,7 @@ export const RepoPage = ({ match }) => {
   return (
     <div>
       <SwitchUserButton />
-      <Heading fontSize="32px" mt="25px" textAlign="center">
+      <Heading fontSize="28px" mt="25px" textAlign="left">
         <Link href={repoURL} isExternal>
           {repo}
         </Link>

--- a/src/components/repo-list/RepoList.js
+++ b/src/components/repo-list/RepoList.js
@@ -28,19 +28,27 @@ const Repo = ({ repo, user, shouldShowForks }) => {
   return (
     <Box mb="12px" w="550px">
       <Flex align="baseline" justify="space-between">
-        <Link as={RouterLink} to={`${user}/repo/${name}`}>
-          <Text fontSize="24px">{name}</Text>
+        <Link
+          as={RouterLink}
+          to={`${user}/repo/${name}`}
+          textDecoration="underline"
+        >
+          <Text fontSize="20px">{name}</Text>
         </Link>
         {starsForDisplay}
         {fork && <GithubForkIcon />}
       </Flex>
 
-      <Text fontSize="14px" mb="10px" isTruncated>
+      <Text color="#808080" fontSize="14px" mb="10px" isTruncated>
         {description}
       </Text>
 
-      <Text fontSize="14px">{language}</Text>
-      <Text fontSize="14px">{updatedAtForDisplay}</Text>
+      <Text color="#808080" fontSize="14px">
+        {language}
+      </Text>
+      <Text color="#808080" fontSize="14px">
+        {updatedAtForDisplay}
+      </Text>
       <Divider borderColor="#808080" mt="12px" />
     </Box>
   );


### PR DESCRIPTION
#### Summary

<!-- Replace N/A with link to issue or card if applicable-->
<!-- Bullet points describing what this PR does -->
- Change text to grey on various places in User and Repo pages
- Styling tweaks to heading sizes

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
