### PR TITLE
chore(webpack): add mode for production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
     historyApiFallback: true,
     contentBase: './',
   },
-  devtool: 'eval-source-map',
+  devtool: isProduction ? 'none' : 'eval-source-map',
   module: {
     rules: [
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const DotenvPlugin = require('dotenv-webpack');
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 module.exports = {
-  mode: 'development',
+  mode: isProduction ? 'production' : 'development',
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
#### Summary

<!-- Replace N/A with link to issue or card if applicable-->
Resolves: N/A
Card if applicable: [split webpack config so that we dont have a source map on production](https://github.com/f1v/full-git-commit-history-app/projects/1#card-52674340)

<!-- Bullet points describing what this PR does -->
- reduces bundle size from 4.4 MB -> 614 KB

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
