### PR TITLE
fix(repo-page): fix master branch duplication on commit list

### DIFF
--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -13,6 +13,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
+import { orderRepoBranches } from '../../utils';
+
 const SelectDropdown = ({ currentBranch, defaultValue, options, onSelect }) => {
   return (
     <Flex justifyContent="flex-end" mb="25px">
@@ -80,6 +82,7 @@ export const CommitList = ({
   defaultBranch,
 }) => {
   const history = useHistory();
+  const options = orderRepoBranches(branches, defaultBranch);
 
   const onSelect = (event) => {
     event.preventDefault();
@@ -87,16 +90,6 @@ export const CommitList = ({
     const branch = window.btoa(event.target.value);
     history.push(`/user/${user}/repo/${repo}/branch/${branch}`);
   };
-
-  const moveDefaultBranchToTop = (repoBranches) => {
-    const copy = repoBranches.slice();
-    const defaultBranchIndex = copy.indexOf(defaultBranch);
-    copy.splice(defaultBranchIndex, 1);
-    copy.unshift(defaultBranch);
-    return copy;
-  };
-
-  const options = moveDefaultBranchToTop(branches);
 
   return commits.length ? (
     <>

--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -15,6 +15,8 @@ import { useHistory } from 'react-router-dom';
 
 import { orderRepoBranches } from '../../utils';
 
+// TODO: Make this its own component file and more generic
+// refactor with UserPage Select Dropdown
 const SelectDropdown = ({ currentBranch, defaultValue, options, onSelect }) => {
   return (
     <Flex justifyContent="flex-end" mb="25px">

--- a/src/components/commit-list/CommitList.js
+++ b/src/components/commit-list/CommitList.js
@@ -13,6 +13,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
+const SelectDropdown = ({ currentBranch, defaultValue, options, onSelect }) => {
+  return (
+    <Flex justifyContent="flex-end" mb="25px">
+      <Select
+        borderColor="#808080"
+        color="#808080"
+        fontSize="15px"
+        onChange={onSelect}
+        w="160px"
+        value={currentBranch || defaultValue}
+      >
+        {options.map((branchName, index) => {
+          return (
+            <option key={index} value={branchName}>
+              {branchName}
+            </option>
+          );
+        })}
+      </Select>
+    </Flex>
+  );
+};
+
 const Commit = ({ githubCommitObject }) => {
   const { sha, commit, html_url: url } = githubCommitObject;
   const { commiter, author, message } = commit;
@@ -48,7 +71,14 @@ const Commit = ({ githubCommitObject }) => {
   );
 };
 
-export const CommitList = ({ commits, branches, user, repo, branch }) => {
+export const CommitList = ({
+  commits,
+  branches,
+  user,
+  repo,
+  branch,
+  defaultBranch,
+}) => {
   const history = useHistory();
 
   const onSelect = (event) => {
@@ -58,37 +88,26 @@ export const CommitList = ({ commits, branches, user, repo, branch }) => {
     history.push(`/user/${user}/repo/${repo}/branch/${branch}`);
   };
 
-  const SelectDropdown = () => {
-    // TODO: add functionality for the edge case where a repo starts with main branch instead of master
-    return (
-      <Flex justifyContent="flex-end" mb="25px">
-        <Select
-          borderColor="#808080"
-          color="#808080"
-          fontSize="15px"
-          onChange={onSelect}
-          w="160px"
-          value={branch}
-        >
-          <option value="master">master</option>
-          {branches.map((branchName, index) => {
-            return (
-              <option key={index} value={branchName}>
-                {branchName}
-              </option>
-            );
-          })}
-        </Select>
-      </Flex>
-    );
+  const moveDefaultBranchToTop = (repoBranches) => {
+    const copy = repoBranches.slice();
+    const defaultBranchIndex = copy.indexOf(defaultBranch);
+    copy.splice(defaultBranchIndex, 1);
+    copy.unshift(defaultBranch);
+    return copy;
   };
+
+  const options = moveDefaultBranchToTop(branches);
 
   return commits.length ? (
     <>
       <Box mt="25px" textAlign="left">
         <Flex align="baseline" justify="space-between" mb="18px" w="550px">
           <Heading fontSize="28px">Commit History</Heading>
-          <SelectDropdown />
+          <SelectDropdown
+            currentBranch={branch}
+            options={options}
+            onSelect={onSelect}
+          />
         </Flex>
 
         <Divider mb="12px" />
@@ -103,9 +122,10 @@ export const CommitList = ({ commits, branches, user, repo, branch }) => {
 CommitList.propTypes = {
   commits: PropTypes.arrayOf(PropTypes.object),
   branches: PropTypes.arrayOf(PropTypes.string),
+  branch: PropTypes.string,
   user: PropTypes.string,
   repo: PropTypes.string,
-  branch: PropTypes.string,
+  defaultBranch: PropTypes.string,
 };
 
 Commit.propTypes = {
@@ -118,4 +138,11 @@ Commit.propTypes = {
     sha: PropTypes.string,
     url: PropTypes.string,
   }),
+};
+
+SelectDropdown.propTypes = {
+  currentBranch: PropTypes.string,
+  defaultValue: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.string),
+  onSelect: PropTypes.func,
 };

--- a/src/utils/githubApiUtil.js
+++ b/src/utils/githubApiUtil.js
@@ -27,6 +27,20 @@ const getUserRepos = async ({ username }) => {
 };
 
 /**
+ * @param {Object} param
+ * @param {String} param.owner
+ * @param {String} param.repo
+ * @example endpoint: https://api.github.com/repos/f1v/full-git-commit-history-app
+ * @example description: https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-a-repository
+ */
+const getRepo = async ({ owner, repo }) => {
+  return await octoRequest('GET /repos/{owner}/{repo}', {
+    owner,
+    repo,
+  });
+};
+
+/**
  * returns entire commit history from looking up SHAs
  * @param {Object} param
  * @param {String} param.owner github username; e.g. facebook
@@ -118,4 +132,7 @@ export const API = {
   getUserRepos,
   getRepoCommitHistory,
   getRepoBranches,
+  getRepo,
 };
+
+window.api = API;

--- a/src/utils/githubDataUtil.js
+++ b/src/utils/githubDataUtil.js
@@ -24,7 +24,7 @@ export const sortReposList = (repos, sortType) => {
  * takes an array of from github data objects like
  * https://api.github.com/users/f1v/repos
  * and returns a filtered array with only relevant keys
- * @param {Array} userData
+ * @param {Array} userData; array of repositories data
  */
 export const parseUserData = (userData) => {
   return userData.map(
@@ -36,7 +36,17 @@ export const parseUserData = (userData) => {
       pushed_at: pushedAt,
       stargazers_count: numStars,
       fork,
-    }) => ({ id, name, description, language, pushedAt, numStars, fork }),
+      default_branch: defaultBranch,
+    }) => ({
+      id,
+      name,
+      description,
+      language,
+      pushedAt,
+      numStars,
+      fork,
+      defaultBranch,
+    }),
   );
 };
 
@@ -44,7 +54,7 @@ export const parseUserData = (userData) => {
  * takes an array of from github data objects like
  * https://api.github.com/repos/f1v/full-git-commit-history-app/commits?sha=461682a
  * and returns a filtered array with only relevant keys
- * @param {Array} repoData
+ * @param {Array} repoData; array of commits data
  */
 export const parseRepoData = (repoData) => {
   return repoData.map(

--- a/src/utils/githubDataUtil.js
+++ b/src/utils/githubDataUtil.js
@@ -63,3 +63,16 @@ export const parseRepoData = (repoData) => {
     },
   );
 };
+
+/**
+ * takes a list of branches and puts the main branch at the top
+ * @param {Array<String>} branches
+ * @param {String} mainBranch
+ */
+export const orderRepoBranches = (branches, mainBranch) => {
+  const copy = branches.slice();
+  const defaultBranchIndex = copy.indexOf(mainBranch);
+  copy.splice(defaultBranchIndex, 1);
+  copy.unshift(mainBranch);
+  return copy;
+};

--- a/src/utils/githubDataUtil.js
+++ b/src/utils/githubDataUtil.js
@@ -67,12 +67,12 @@ export const parseRepoData = (repoData) => {
 /**
  * takes a list of branches and puts the main branch at the top
  * @param {Array<String>} branches
- * @param {String} mainBranch
+ * @param {String} defaultBranch
  */
-export const orderRepoBranches = (branches, mainBranch) => {
+export const orderRepoBranches = (branches, defaultBranch) => {
   const copy = branches.slice();
-  const defaultBranchIndex = copy.indexOf(mainBranch);
+  const defaultBranchIndex = copy.indexOf(defaultBranch);
   copy.splice(defaultBranchIndex, 1);
-  copy.unshift(mainBranch);
+  copy.unshift(defaultBranch);
   return copy;
 };


### PR DESCRIPTION
#### Summary

<!-- Replace N/A with link to issue or card if applicable-->
Resolves: N/A
Card if applicable: 
[Can we check branch array if it includes master or main, if it includes main then use that instead of master](https://github.com/f1v/full-git-commit-history-app/projects/1#card-52735005)
[master branch is showing twice in branch dropdown](https://github.com/f1v/full-git-commit-history-app/projects/1#card-52697972)

<!-- Bullet points describing what this PR does -->
- adds logic to find main branch
- has main branch at top of select list

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in semantic format `TYPE(scope): description`
